### PR TITLE
fix: query parser should accept underscores in values

### DIFF
--- a/vastai_sdk/vastai_sdk.py
+++ b/vastai_sdk/vastai_sdk.py
@@ -59,7 +59,7 @@ def queryParser(kwargs):
 
     key = Word(alphas + "_-")
     operator = oneOf("= in != > < >= <=")
-    value = Word(alphanums) | quotedString
+    value = Word(alphanums + "_") | quotedString
     expr = Group(key + operator + value)
     query = ZeroOrMore(expr)
     parsed = query.parseString(qstr)


### PR DESCRIPTION
From the help docs for `search_offers`:

> [...] note: to encode a string query value (ie for gpu_name), replace any spaces ' ' with underscore '_'

The current parser parses the query `gpu_name = RTX_4090` as `[['gpu_name', '=', 'RTX']]`, which results in no offers being returned from the API call.

By allowing values to have underscores, the same query can be parsed as `[['gpu_name', '=', 'RTX_4090']]`, which is what is expected and results in offers being returned.