### PR TITLE
relax borb dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "jsonschema>=3.2",
 		"xdg>=1.0.0",
 		"requests==2.32.3",
-		"borb==2.0.17",
+        "borb~=2.0.17",
 		"python-dateutil",
         "pyparsing",
 		"pytz",


### PR DESCRIPTION
This is needed to fix skypilot-org/skypilot#5153, and also for python >=3.12 support for skypilot.
Basically, borb 2.0.17 relies on an insanely old version of setuptools, which causes huge dependency headaches. borb 2.0.18 and onward relax that requirement.