### PR TITLE
(vastai_sdk.py) Improve debug output on troubleshooting

### DIFF
--- a/vastai_sdk/vastai_sdk.py
+++ b/vastai_sdk/vastai_sdk.py
@@ -283,19 +283,20 @@ class VastAI(VastAIBase):
             if logger.isEnabledFor(logging.DEBUG):
                kwargs_repr = {key: repr(value) for key, value in kwargs.items()}
                logging.debug(f"Calling {func.__name__} with arguments: kwargs={kwargs_repr}")
-
-            out_b = io.StringIO()
-            out_o = sys.stdout
-            sys.stdout = out_b
+            else:
+                out_b = io.StringIO()
+                out_o = sys.stdout
+                sys.stdout = out_b
 
             res = func(args) 
 
             if func.__name__ in _hooks:
               res = _hooks[func.__name__][1](state, res)
 
-            sys.stdout = out_o
-            self.last_output = out_b.getvalue()
-            out_b.close()
+            if not logger.isEnabledFor(logging.DEBUG):
+                sys.stdout = out_o
+                self.last_output = out_b.getvalue()
+                out_b.close()
 
             if hasattr(res, 'json'):
                logging.debug(f" └-> {res.json()}")


### PR DESCRIPTION
```
out_b = io.StringIO()
out_o = sys.stdout
sys.stdout = out_b
```
Effectively disable direct stdout and keep it buffered. For example in situationwhen i had mistake with instance_create(), parameter `onstart` pointed to non-existing file - this supressed exception and any debugging. Program just silently quit on function call without any error.
This commit disable buffering if logging.DEBUG is enabled, to help troubleshooting such situations.