### PR TITLE
Ensure fstring is compatible with python < 3.12

### DIFF
--- a/vastai/serverless/client/client.py
+++ b/vastai/serverless/client/client.py
@@ -180,7 +180,7 @@ class Serverless:
         if not isinstance(endpoint, Endpoint):
             raise ValueError("endpoint must be an Endpoint")
 
-        url = f"{self.autoscaler_url}{"/get_endpoint_workers/"}"
+        url = f"{self.autoscaler_url}/get_endpoint_workers/"
         payload = {"id": endpoint.id, "api_key": self.api_key}
 
         async with self._session.post(url, json=payload, timeout=aiohttp.ClientTimeout(total=30)) as resp:


### PR DESCRIPTION
We're still targeting Python pre 3.12 

`url = f"{self.autoscaler_url}{"/get_endpoint_workers/"}"` will result in an error in earlier versions so this PR makes a slight adjustment in formatting to keep compatibility