### PR TITLE
Fixing dictionary/list issue in get_endpoint_workers functionality

### DIFF
--- a/vastai/serverless/client/client.py
+++ b/vastai/serverless/client/client.py
@@ -196,7 +196,7 @@ class Serverless:
             # should normally return a list of dictionaries containing worker instance information.
             if isinstance(data,dict):
                 if 'error_msg' in data.keys():
-                    print(f"[Warning] Received the following error from get_endpoint_workers:{data['error_msg']}.\nEndpoint may not be ready for query. Check credentials or wait a few minutes and try again.")
+                    self.logger.warning(f"Received the following error from get_endpoint_workers:{data['error_msg']}.\nEndpoint may not be ready for query. Check credentials or wait a few minutes and try again.")
                     return []
 
             


### PR DESCRIPTION
Summary

The serverless TGI template needs to be tested with the Server SDK, specifically referencing Lucas's PR branch in the pyworker repository.

Context

Lucas has a PR opened in the pyworker repository on GitHub. The goal is to test the TGI template using the new pyworker server sdk logic. In the Use PyWorker SDK Pull Request, Lucas created vast templates for testing.

The testing script that came out of this work uses an Endpoint monitor to ping the TGI endpoint. While the worker instances within the endpoint are loading, the Endpoint monitor continually throws an error within the get_endpoint_worker function. It is expecting a list and the output is a dictionary. This pull request contains the error catching code to prevent this behavior from happening.