### PR TITLE
Cap aiohttp version to <3.13.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ urllib3 = ">=2.0,<3.0"
 pyparsing = ">=3.1,<4.0"
 fastapi = ">=0.110,<1.0"
 uvicorn = { version = ">=0.24,<0.32", extras = ["standard"] }
-aiohttp = ">=3.9.1" 
+aiohttp = ">=3.9.1,<3.13.4"
 aiodns = ">=3.6.0" 
 pycares = "=4.11.0"
 anyio = "~4.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ urllib3 = ">=2.0,<3.0"
 pyparsing = ">=3.1,<4.0"
 fastapi = ">=0.110,<1.0"
 uvicorn = { version = ">=0.24,<0.32", extras = ["standard"] }
-aiohttp = ">=3.9.1,<3.13.4"
+aiohttp = ">=3.9.1,<3.13.4" # TODO: 3.13.4 breaks autoscaler headers, rm once fixed
 aiodns = ">=3.6.0" 
 pycares = "=4.11.0"
 anyio = "~4.4"


### PR DESCRIPTION
aiohttp 3.13.4 causes compatibility issues with the autoscaler regarding headers. Pinning version less than 3.13.4 for now until fix is released on autoscaler side.